### PR TITLE
Fixed wishlist event name

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -50,7 +50,7 @@ ___TEMPLATE_PARAMETERS___
             "displayValue": "AddToCart"
           },
           {
-            "value": "AddToWishList",
+            "value": "AddToWishlist",
             "displayValue": "AddToWishlist"
           },
           {
@@ -1611,5 +1611,3 @@ scenarios: []
 ___NOTES___
 
 Version 0.3
-
-


### PR DESCRIPTION
The standard Facebook pixel event is AddToWishlist (https://www.facebook.com/business/help/402791146561655?id=1205376682832142), as it stands gets counted as a custom event. 
This fixes the syntax.